### PR TITLE
Fix Cirrus bug that uses the actual database instead of the emulator

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -533,6 +533,7 @@
                   <entry key="Bootcamp" value="120" />
                   <entry key="Duration" value="90" />
                   <entry key="Pixel_2_API_30" value="120" />
+                  <entry key="Pixel_2_API_33" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>

--- a/app/src/androidTest/java/com/github/sdp/mediato/AuthenticationActivityTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/AuthenticationActivityTest.java
@@ -18,6 +18,7 @@ import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 
 import com.firebase.ui.auth.AuthUI;
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -113,7 +114,7 @@ public class AuthenticationActivityTest {
         FirebaseAuth auth = FirebaseAuth.getInstance();
         try {
             auth.useEmulator("10.0.2.2", 9099);
-            UserDatabase.database.useEmulator("10.0.2.2", 9000);
+            DatabaseTestsUtil.useEmulator();
         } catch (IllegalStateException ignored) {
         }
 
@@ -121,7 +122,7 @@ public class AuthenticationActivityTest {
             auth.signOut();
         }
 
-        UserDatabase.database.getReference().setValue(null);
+        DatabaseTestsUtil.cleanDatabase();
 
         testRule.getScenario().onActivity(activity1 -> activity = activity1);
     }

--- a/app/src/androidTest/java/com/github/sdp/mediato/CreateProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/CreateProfileFragmentTest.java
@@ -23,6 +23,7 @@ import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.matcher.BoundedMatcher;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.google.android.material.textfield.TextInputLayout;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/CollectionsTests.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/CollectionsTests.java
@@ -59,7 +59,7 @@ public class CollectionsTests {
     @Before
     public void setUp() throws ExecutionException, InterruptedException, TimeoutException {
         try {
-            UserDatabase.database.useEmulator("10.0.2.2", 9000);
+            DatabaseTestsUtil.useEmulator();
         } catch (Exception ignored) {
         }
         UserDatabase.addUser(user1).get(STANDARD_COLLECTION_TIMEOUT, TimeUnit.SECONDS);
@@ -71,7 +71,7 @@ public class CollectionsTests {
 
     @AfterClass
     public static void cleanDatabase() {
-      UserDatabase.database.getReference().setValue(null);
+      DatabaseTestsUtil.cleanDatabase();
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/DatabaseTestsUtil.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/DatabaseTestsUtil.java
@@ -1,0 +1,24 @@
+package com.github.sdp.mediato.DatabaseTests;
+
+import com.github.sdp.mediato.data.CollectionsDatabase;
+import com.github.sdp.mediato.data.UserDatabase;
+import com.github.sdp.mediato.model.User;
+
+public class DatabaseTestsUtil {
+
+    /**
+     * Util function to make the database use the emulator
+     */
+    public static void useEmulator() {
+        UserDatabase.database.useEmulator("10.0.2.2", 9000);
+        CollectionsDatabase.database.useEmulator("10.0.2.2", 9000);
+    }
+
+    /**
+     * Clean the databases
+     */
+    public static void cleanDatabase() {
+        UserDatabase.database.getReference().setValue(null);
+        CollectionsDatabase.database.getReference().setValue(null);
+    }
+}

--- a/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/LocationTests.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/LocationTests.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import android.database.DatabaseUtils;
+
+import com.github.sdp.mediato.data.CollectionsDatabase;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -41,7 +44,7 @@ public class LocationTests {
     @Before
     public void setUp() throws ExecutionException, InterruptedException, TimeoutException {
         try {
-            UserDatabase.database.useEmulator("10.0.2.2", 9000);
+            DatabaseTestsUtil.useEmulator();
         } catch (Exception ignored) {
         }
         //Create new sample user
@@ -83,7 +86,7 @@ public class LocationTests {
 
     @AfterClass
     public static void cleanDatabase() {
-        UserDatabase.database.getReference().setValue(null);
+        DatabaseTestsUtil.cleanDatabase();
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/UserTests.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/DatabaseTests/UserTests.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.github.sdp.mediato.data.CollectionsDatabase;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -38,7 +39,7 @@ public class UserTests {
     @Before
     public void setUp() {
         try {
-            UserDatabase.database.useEmulator("10.0.2.2", 9000);
+            DatabaseTestsUtil.useEmulator();
         } catch (Exception ignored) {
         }
         //Create new sample users
@@ -64,7 +65,7 @@ public class UserTests {
 
     @AfterClass
     public static void cleanDatabase() {
-        UserDatabase.database.getReference().setValue(null);
+        DatabaseTestsUtil.cleanDatabase();
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
@@ -83,6 +83,11 @@ public class MyFollowersFragmentTest {
     });
   }
 
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
+  }
+
   @Test
   public void testRecyclerViewWithNoneFollowing() {
     assertRecyclerViewItemCount(R.id.myFollowers_recyclerView, 0);

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
@@ -83,11 +83,6 @@ public class MyFollowersFragmentTest {
     });
   }
 
-  @AfterClass
-  public static void cleanDatabase() {
-    DatabaseTestsUtil.cleanDatabase();
-  }
-
   @Test
   public void testRecyclerViewWithNoneFollowing() {
     assertRecyclerViewItemCount(R.id.myFollowers_recyclerView, 0);

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowersFragmentTest.java
@@ -7,9 +7,13 @@ import static com.adevinta.android.barista.interaction.BaristaListInteractions.c
 import static com.adevinta.android.barista.interaction.BaristaSleepInteractions.sleep;
 
 import android.os.Bundle;
+import android.provider.ContactsContract;
+
 import androidx.fragment.app.FragmentManager;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -18,6 +22,8 @@ import com.github.sdp.mediato.ui.MyFollowingFragment;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +39,7 @@ public class MyFollowersFragmentTest {
   public void setUp() throws ExecutionException, InterruptedException, TimeoutException
   {
     try {
-      UserDatabase.database.useEmulator("10.0.2.2", 9000);
+      DatabaseTestsUtil.useEmulator();
     } catch (Exception ignored) {
     }
     //Create new sample users
@@ -75,6 +81,11 @@ public class MyFollowersFragmentTest {
       fragmentManager.beginTransaction().replace(R.id.main_container, myFollowersFragment)
               .commitAllowingStateLoss();
     });
+  }
+
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
@@ -83,6 +83,11 @@ public class MyFollowingFragmentTest {
     });
   }
 
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
+  }
+
   @Test
   public void testRecyclerViewWithNoneFollowing() {
     assertRecyclerViewItemCount(R.id.myFollowing_recyclerView, 0);

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
@@ -7,16 +7,19 @@ import static com.adevinta.android.barista.interaction.BaristaListInteractions.c
 import static com.adevinta.android.barista.interaction.BaristaSleepInteractions.sleep;
 
 import android.os.Bundle;
+import android.provider.ContactsContract;
 
 import androidx.fragment.app.FragmentManager;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
 import com.github.sdp.mediato.ui.MyFollowingFragment;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +39,7 @@ public class MyFollowingFragmentTest {
   public void setUp() throws ExecutionException, InterruptedException, TimeoutException
   {
     try {
-      UserDatabase.database.useEmulator("10.0.2.2", 9000);
+      DatabaseTestsUtil.useEmulator();
     } catch (Exception ignored) {
     }
     //Create new sample users
@@ -78,6 +81,11 @@ public class MyFollowingFragmentTest {
       fragmentManager.beginTransaction().replace(R.id.main_container, myFollowingFragment)
               .commitAllowingStateLoss();
     });
+  }
+
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyFollowingFragmentTest.java
@@ -83,11 +83,6 @@ public class MyFollowingFragmentTest {
     });
   }
 
-  @AfterClass
-  public static void cleanDatabase() {
-    DatabaseTestsUtil.cleanDatabase();
-  }
-
   @Test
   public void testRecyclerViewWithNoneFollowing() {
     assertRecyclerViewItemCount(R.id.myFollowing_recyclerView, 0);

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
@@ -111,8 +111,9 @@ public class MyProfileFragmentTest {
     });
   }
 
-  private void storeUsers(){
-
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
   }
 
   // Test whether the "Following" button is displayed and contains the correct text

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
@@ -12,6 +12,7 @@ import static java.lang.Thread.sleep;
 import static org.junit.Assert.fail;
 
 import android.os.Bundle;
+import android.provider.ContactsContract;
 import android.view.View;
 import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -25,6 +26,7 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 import com.adevinta.android.barista.interaction.BaristaSleepInteractions;
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -34,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +71,7 @@ public class MyProfileFragmentTest {
 
     // Use Database emulator
     try {
-      UserDatabase.database.useEmulator("10.0.2.2", 9000);
+      DatabaseTestsUtil.useEmulator();
     } catch (Exception ignored) {
     }
 
@@ -104,6 +107,11 @@ public class MyProfileFragmentTest {
       fragmentManager.beginTransaction().replace(R.id.main_container, myProfileFragment)
           .commitAllowingStateLoss();
     });
+  }
+
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
   }
 
   private void storeUsers(){

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
@@ -36,8 +36,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -122,8 +124,9 @@ public class MyProfileFragmentTest {
 
   // Tests that following a user updates the count on the following button when getting back to the profile page
   @Test
-  public void testAddFollowingUpdatesFollowingButton() {
+  public void testAddFollowingUpdatesFollowingButton() throws InterruptedException {
     UserDatabase.followUser(MY_USERNAME, user2.getUsername());
+    Thread.sleep(1000);
     searchMenuItem.perform(click());
     profileMenuItem.perform(click());
     followingButton.check(matches(withText("1 Following")));
@@ -145,8 +148,9 @@ public class MyProfileFragmentTest {
 
   // Tests getting a new follower updates the count on the following button when getting back to the profile page
   @Test
-  public void testAddFollowerUpdatesFollowerButton() {
+  public void testAddFollowerUpdatesFollowerButton() throws InterruptedException {
     UserDatabase.followUser(user2.getUsername(), MY_USERNAME);
+    Thread.sleep(1000);
     searchMenuItem.perform(click());
     profileMenuItem.perform(click());
     followersButton.check(matches(withText("1 Followers")));

--- a/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/MyProfileFragmentTest.java
@@ -109,11 +109,6 @@ public class MyProfileFragmentTest {
     });
   }
 
-  @AfterClass
-  public static void cleanDatabase() {
-    DatabaseTestsUtil.cleanDatabase();
-  }
-
   private void storeUsers(){
 
   }

--- a/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
@@ -24,6 +24,8 @@ import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
+
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.CollectionsDatabase;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
@@ -37,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,7 +60,7 @@ public class ReadOnlyProfileFragmentTest {
   public void setUp() throws ExecutionException, InterruptedException, TimeoutException {
     // Use Database emulator
     try {
-      UserDatabase.database.useEmulator("10.0.2.2", 9000);
+      DatabaseTestsUtil.useEmulator();
     } catch (Exception ignored) {
     }
 
@@ -76,6 +79,11 @@ public class ReadOnlyProfileFragmentTest {
       fragmentManager.beginTransaction().replace(R.id.main_container, readOnlyProfileFragment)
           .commitAllowingStateLoss();
     });
+  }
+
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
   }
 
   // Test whether the "Following" button is displayed and contains the correct text

--- a/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
@@ -81,11 +81,6 @@ public class ReadOnlyProfileFragmentTest {
     });
   }
 
-  @AfterClass
-  public static void cleanDatabase() {
-    DatabaseTestsUtil.cleanDatabase();
-  }
-
   // Test whether the "Following" button is displayed and contains the correct text
   @Test
   public void testFollowingButton() {

--- a/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/ReadOnlyProfileFragmentTest.java
@@ -81,6 +81,11 @@ public class ReadOnlyProfileFragmentTest {
     });
   }
 
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
+  }
+
   // Test whether the "Following" button is displayed and contains the correct text
   @Test
   public void testFollowingButton() {

--- a/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
@@ -22,6 +22,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.github.sdp.mediato.DatabaseTests.DatabaseTestsUtil;
 import com.github.sdp.mediato.data.UserDatabase;
 import com.github.sdp.mediato.model.Location;
 import com.github.sdp.mediato.model.User;
@@ -29,6 +30,7 @@ import com.github.sdp.mediato.ui.SearchFragment;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +53,7 @@ public class SearchFragmentTest {
   public void setUp() throws ExecutionException, InterruptedException, TimeoutException
   {
     try {
-      UserDatabase.database.useEmulator("10.0.2.2", 9000);
+      DatabaseTestsUtil.useEmulator();
     } catch (Exception ignored) {
     }
     //Create new sample users
@@ -101,6 +103,12 @@ public class SearchFragmentTest {
               .commitAllowingStateLoss();
     });
   }
+
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
+  }
+
   @Test
   public void testUserSearchWithEmptyString() {
     clickOn(androidx.appcompat.R.id.search_button);

--- a/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
@@ -104,6 +104,11 @@ public class SearchFragmentTest {
     });
   }
 
+  @AfterClass
+  public static void cleanDatabase() {
+    DatabaseTestsUtil.cleanDatabase();
+  }
+
   @Test
   public void testUserSearchWithEmptyString() {
     clickOn(androidx.appcompat.R.id.search_button);

--- a/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
+++ b/app/src/androidTest/java/com/github/sdp/mediato/SearchFragmentTest.java
@@ -104,11 +104,6 @@ public class SearchFragmentTest {
     });
   }
 
-  @AfterClass
-  public static void cleanDatabase() {
-    DatabaseTestsUtil.cleanDatabase();
-  }
-
   @Test
   public void testUserSearchWithEmptyString() {
     clickOn(androidx.appcompat.R.id.search_button);


### PR DESCRIPTION
This PR fixes #140 by adding util functions that make both CollectionsDatabase and UserDatabase use the emulator (as well as another cleanDatabase method). I also added those in the test classes that weren't using the emulator for both Database classes. 